### PR TITLE
Add public initializer to MulticastDelegate

### DIFF
--- a/Source/MulticastDelegate/MulticastDelegate.swift
+++ b/Source/MulticastDelegate/MulticastDelegate.swift
@@ -12,7 +12,10 @@ import Foundation
 open class MulticastDelegate <T> {
   /// List of delegates
   private let delegates: NSHashTable<AnyObject> = NSHashTable.weakObjects()
-  
+
+  /// Public init. The generated init is 'internal'
+  public init() {}
+
   /**
    Add delegate in list of delegates.
    


### PR DESCRIPTION
Since the generated initializer is 'internal', users of the library were unable to initialize MulticastDelegate which was also causing them to be unable to create their own TextInput.

Solves:
https://github.com/luximetr/AnyFormatKit/issues/9
https://github.com/luximetr/AnyFormatKit/issues/6