### PR TITLE
Allow to delete groupingSeparator

### DIFF
--- a/Source/TextFormatter/SumFormatters/SumTextInputFormatter.swift
+++ b/Source/TextFormatter/SumFormatters/SumTextInputFormatter.swift
@@ -140,7 +140,12 @@ open class SumTextInputFormatter: SumTextFormatter, TextInputFormatterProtocol {
     if range.length == 1 {
       if range.location > text.count - (suffixStr?.count ?? 0) - 1 ||
         range.location < (prefix?.count ?? 0)
-      { return nil }
+      {
+        return nil
+      } else if let deleteRange = Range(range, in: text), text[deleteRange] == groupingSeparator {
+        let newRange = NSRange(location: range.location - 1, length: range.length )
+        return newRange
+      }
     } else {
       
       var lowerBound = range.lowerBound


### PR DESCRIPTION
Currently, it's not possible to delete a grouping symbol:
![delete_grouping_separator](https://user-images.githubusercontent.com/872805/56235482-3313bf00-6090-11e9-9234-394f8364b30c.gif)
