### PR TITLE
Fix bug where a stackoverflow would occur when AttributedTextInputField is used.

### DIFF
--- a/Source/TextInput/AttributedTextInput/AttributedTextInputField.swift
+++ b/Source/TextInput/AttributedTextInput/AttributedTextInputField.swift
@@ -15,7 +15,7 @@ open class AttributedTextInputField: UITextField {
   override open var text: String? {
     set { super.attributedText = attributedStringConstructor.attributedStringWithAttributes(
       newValue: newValue, commonAttributes: convertFromNSAttributedStringKeyDictionary(defaultTextAttributes)) }
-    get { return super.attributedText?.string }
+    get { return super.text }
   }
   
   /// Common attributes for all string during typing


### PR DESCRIPTION
@luximetr As you mentioned, you had a feeling a problem occurred in the past with the overriding of text and attributedText. I researched it a bit more and as it turns out the current implementation of `AttributedTextInputField` is not working and is causing a stackoverflow.

The current implementation is as follows:
When 'attributedText', is retrieved (get), UIKit also retrieves value for `text`, but since the override indicates that it should get 'attributedText' instead, it's causing an infinite loop. It was 'fixed' previously by subclassing it (`TextInputField`) and nilifying the text property (by overriding), it was also 'fixed' by implementing the 'shouldChangeTextIn' and returning false.

Currently, AttributedTextInputField cannot be used a stand-alone component, causing a BadAcces (and a crash), this PR should solve this problem.

Let me know what you think